### PR TITLE
Refactor database initialization and migrations to SQLAlchemy

### DIFF
--- a/maica/initializer/init_db.py
+++ b/maica/initializer/init_db.py
@@ -2,244 +2,69 @@
 Do not add future inits here, since it's actually migration_0. Make new migs instead.
 """
 
-import asyncio
 import os
-from typing import *
+import urllib.parse
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
 from maica.maica_utils import *
+
+
+async def _database_exists(engine, database_name: str) -> bool:
+    result = await engine.execute(text("SHOW DATABASES LIKE :database_name"), {"database_name": database_name})
+    return result.first() is not None
+
+
+async def _create_mysql_database(engine, database_name: str):
+    # Database names come from application settings; quote backticks defensively for MySQL identifiers.
+    quoted_name = database_name.replace("`", "``")
+    await engine.execute(text(f"CREATE DATABASE IF NOT EXISTS `{quoted_name}`"))
+
 
 async def create_tables():
 
     AUTH_DB = G.A.AUTH_DB
     MAICA_DB = G.A.DATA_DB
 
-    basic_pool = await ConnUtils.basic_pool()
     auth_created = False
 
-    if basic_pool:
-        # We have to create databases before tables
-        result = await basic_pool.query_get("SHOW DATABASES", fetchall=True)
-        curr_dbs = []
-        for curr_db in result:
-            curr_dbs.append(curr_db[0])
+    if not is_auth_sqlite() or not is_data_sqlite():
+        usr = G.A.DB_USER
+        pwd = urllib.parse.quote_plus(G.A.DB_PASSWORD)
+        addr = G.A.DB_ADDR
+        server_url = f"mysql+aiomysql://{usr}:{pwd}@{addr}"
+        server_engine = create_async_engine(server_url, pool_pre_ping=True, pool_recycle=3600)
+        try:
+            async with server_engine.begin() as conn:
+                if not is_auth_sqlite():
+                    if not await _database_exists(conn, AUTH_DB):
+                        sync_messenger(info=f"[maica-db] AUTH_DB {AUTH_DB} does not exist, creating...", type=MsgType.DEBUG)
+                        await _create_mysql_database(conn, AUTH_DB)
+                        auth_created = True
+                    else:
+                        sync_messenger(info=f"[maica-db] AUTH_DB {AUTH_DB} exists, skipping...", type=MsgType.WARN)
 
-        if not AUTH_DB in curr_dbs:
-            sync_messenger(info=f"[maica-db] AUTH_DB {AUTH_DB} does not exist, creating...", type=MsgType.DEBUG)
-            await basic_pool.query_modify(f"CREATE DATABASE IF NOT EXISTS {AUTH_DB}")
-            auth_created = True
-        else:
-            sync_messenger(info=f"[maica-db] AUTH_DB {AUTH_DB} exists, skipping...", type=MsgType.WARN)
+                if not is_data_sqlite():
+                    if not await _database_exists(conn, MAICA_DB):
+                        sync_messenger(info=f"[maica-db] DATA_DB {MAICA_DB} does not exist, creating...", type=MsgType.DEBUG)
+                        await _create_mysql_database(conn, MAICA_DB)
+                    else:
+                        sync_messenger(info=f"[maica-db] DATA_DB {MAICA_DB} exists, skipping...", type=MsgType.WARN)
+        finally:
+            await server_engine.dispose()
 
-        if not MAICA_DB in curr_dbs:
-            sync_messenger(info=f"[maica-db] DATA_DB {MAICA_DB} does not exist, creating...", type=MsgType.DEBUG)
-            await basic_pool.query_modify(f"CREATE DATABASE IF NOT EXISTS {MAICA_DB}")
-        else:
-            sync_messenger(info=f"[maica-db] DATA_DB {MAICA_DB} exists, skipping...", type=MsgType.WARN)
-    elif not os.path.exists(get_inner_path(AUTH_DB)):
+    if is_auth_sqlite() and not os.path.exists(get_inner_path(AUTH_DB)):
         auth_created = True
 
-    auth_pool = await ConnUtils.auth_pool(ro=False)
-    maica_pool = await ConnUtils.maica_pool()
-
-    auth_tables = [
-"""
-CREATE TABLE IF NOT EXISTS `users` (
-`id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-`username` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
-`nickname` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-`email` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
-`is_email_confirmed` tinyint(1) NOT NULL DEFAULT '0',
-`password` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
-`suspended_until` datetime DEFAULT NULL,
-PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-"""
-    ] if basic_pool else [
-"""
-CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    username TEXT NOT NULL,
-    nickname TEXT DEFAULT NULL,
-    email TEXT NOT NULL,
-    is_email_confirmed INTEGER NOT NULL DEFAULT 0,
-    password TEXT NOT NULL,
-    suspended_until DATETIME DEFAULT NULL
-);
-"""
-    ]
-    maica_tables = [
-"""
-CREATE TABLE IF NOT EXISTS `account_status` (
-`user_id` int(11) NOT NULL,
-`status` text DEFAULT NULL,
-`preferences` text DEFAULT NULL,
-PRIMARY KEY (`user_id`)
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS `crop_archived` (
-`archive_id` int(11) NOT NULL AUTO_INCREMENT,
-`chat_session_id` int(11) NOT NULL,
-`content` longtext DEFAULT NULL,
-`archived` int(11) DEFAULT NULL,
-PRIMARY KEY (`archive_id`)
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS `chat_session` (
-`chat_session_id` int(11) NOT NULL AUTO_INCREMENT,
-`user_id` int(11) NOT NULL,
-`chat_session_num` int(11) NOT NULL,
-`content` longtext DEFAULT NULL,
-PRIMARY KEY (`chat_session_id`)
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS `csession_archived` (
-`archive_id` int(11) NOT NULL AUTO_INCREMENT,
-`chat_session_id` int(11) NOT NULL,
-`content` longtext DEFAULT NULL,
-PRIMARY KEY (`archive_id`)
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS `persistents` (
-`persistent_id` int(11) NOT NULL AUTO_INCREMENT,
-`user_id` int(11) NOT NULL,
-`chat_session_num` int(11) NOT NULL,
-`content` longtext DEFAULT NULL,
-`timestamp` datetime on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-PRIMARY KEY (`persistent_id`)
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS `triggers` (
-`trigger_id` int(11) NOT NULL AUTO_INCREMENT,
-`user_id` int(11) NOT NULL,
-`chat_session_num` int(11) NOT NULL,
-`content` longtext DEFAULT NULL,
-`timestamp` datetime on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-PRIMARY KEY (`trigger_id`)
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS `ms_cache` (
-`spire_id` int(11) NOT NULL AUTO_INCREMENT,
-`hash` text NOT NULL,
-`content` text DEFAULT NULL,
-`timestamp` datetime on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-PRIMARY KEY (`spire_id`)
-)
-"""
-    ] if basic_pool else [
-"""
-CREATE TABLE IF NOT EXISTS account_status (
-    user_id INTEGER PRIMARY KEY NOT NULL,
-    status TEXT DEFAULT NULL,
-    preferences TEXT DEFAULT NULL
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS crop_archived (
-    archive_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    chat_session_id INTEGER NOT NULL,
-    content TEXT DEFAULT NULL,
-    archived INTEGER DEFAULT NULL
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS chat_session (
-    chat_session_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    chat_session_num INTEGER NOT NULL,
-    content TEXT DEFAULT NULL
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS csession_archived (
-    archive_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    chat_session_id INTEGER NOT NULL,
-    content TEXT DEFAULT NULL
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS persistents (
-    persistent_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    chat_session_num INTEGER NOT NULL,
-    content TEXT DEFAULT NULL,
-    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS triggers (
-    trigger_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    chat_session_num INTEGER NOT NULL,
-    content TEXT DEFAULT NULL,
-    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-)
-""",
-"""
-CREATE TABLE IF NOT EXISTS ms_cache (
-    spire_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    hash TEXT NOT NULL,
-    content TEXT DEFAULT NULL,
-    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-)
-""",
-"""
-CREATE TRIGGER IF NOT EXISTS update_timestamp_persistents
-AFTER UPDATE ON persistents
-FOR EACH ROW
-BEGIN
-    UPDATE persistents
-    SET timestamp = CURRENT_TIMESTAMP
-    WHERE persistent_id = OLD.persistent_id;
-END;
-""",
-"""
-CREATE TRIGGER IF NOT EXISTS update_timestamp_triggers
-AFTER UPDATE ON triggers
-FOR EACH ROW
-BEGIN
-    UPDATE triggers
-    SET timestamp = CURRENT_TIMESTAMP
-    WHERE trigger_id = OLD.trigger_id;
-END;
-""",
-"""
-CREATE TRIGGER IF NOT EXISTS update_timestamp_ms_cache
-AFTER UPDATE ON ms_cache
-FOR EACH ROW
-BEGIN
-    UPDATE ms_cache
-    SET timestamp = CURRENT_TIMESTAMP
-    WHERE spire_id = OLD.spire_id;
-END;
-""",
-    ]
-
-    # Notice: These triggers act as 'on update CURRENT_TIMESTAMP', since
-    # there is no convenient way for this in SQLite.
-
-    if basic_pool:
-        for table in maica_tables:
-            table += " ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
-
     if auth_created:
-        for table in auth_tables:
-            sync_messenger(info="[maica-db] Adding table to AUTH_DB...", type=MsgType.DEBUG)
-            await auth_pool.query_modify(table)
+        sync_messenger(info="[maica-db] Adding table to AUTH_DB...", type=MsgType.DEBUG)
+        async with DatabaseUtils.engine_auth.begin() as conn:
+            await conn.run_sync(SqlBaseAuth.metadata.create_all)
     else:
         sync_messenger(info="\n[maica-db] Warning: AUTH_DB was not created by MAICA, so we're not writing anything for security reason.\nPlease manually make sure AUTH_DB is already ready for authentication, or delete at your own risk.", type=MsgType.WARN)
 
-    for table in maica_tables:
-        sync_messenger(info="[maica-db] Adding table to DATA_DB...", type=MsgType.DEBUG)
-        await maica_pool.query_modify(table)
+    sync_messenger(info="[maica-db] Adding table to DATA_DB...", type=MsgType.DEBUG)
+    async with DatabaseUtils.engine_data.begin() as conn:
+        await conn.run_sync(SqlBaseData.metadata.create_all)
 
     sync_messenger(info="[maica-db] MAICA databse initialization finished", type=MsgType.LOG)
-
-if __name__ == "__main__":
-    from maica import init
-    init()
-    asyncio.run(create_tables())

--- a/maica/initializer/migrations/migration_1.py
+++ b/maica/initializer/migrations/migration_1.py
@@ -1,6 +1,4 @@
-import asyncio
-import os
-from typing import *
+from sqlalchemy import text
 from maica.maica_utils import *
 from .base import register_migration
 
@@ -8,12 +6,13 @@ upper_version = "1.1.007.post3"
 
 async def migrate():
 
-    maica_pool = await ConnUtils.maica_pool()
     try:
-        await maica_pool.query_modify('RENAME TABLE cchop_archived TO crop_archived')
+        async with DatabaseUtils.engine_data.begin() as conn:
+            if conn.dialect.name == "mysql":
+                await conn.execute(text('RENAME TABLE cchop_archived TO crop_archived'))
+            else:
+                await conn.execute(text('ALTER TABLE cchop_archived RENAME TO crop_archived'))
     except Exception as e:
         raise MaicaDbWarning(f'Couldn\'t rename table cchop_archived to crop_archived: {str(e)}, maybe manually done already?') from e
-    finally:
-        await maica_pool.close()
 
 register_migration(upper_version, migrate)

--- a/maica/initializer/migrations/migration_2.py
+++ b/maica/initializer/migrations/migration_2.py
@@ -1,6 +1,4 @@
-import asyncio
-import os
-from typing import *
+from sqlalchemy import text
 from maica.maica_utils import *
 from .base import register_migration
 
@@ -8,45 +6,16 @@ upper_version = "1.2.000.rc2"
 
 async def migrate():
 
-    maica_pool = await ConnUtils.maica_pool()
     try:
-        if maica_pool.db_type == 'mysql':
-            await maica_pool.query_modify('ALTER TABLE `account_status` CHANGE `status` `status` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL; ')
-            await maica_pool.query_modify('ALTER TABLE `account_status` CHANGE `preferences` `preferences` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL; ')
-            await maica_pool.query_modify('ALTER TABLE `ms_cache` CHANGE `hash` `hash` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL; ')
-            await maica_pool.query_modify('ALTER TABLE `ms_cache` CHANGE `content` `content` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL; ')
-            await maica_pool.query_modify("""
-CREATE TABLE IF NOT EXISTS `mv_meta` (
-  `vista_id` int(11) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) NOT NULL,
-  `uuid` text NOT NULL,
-  `timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`vista_id`)
-)
-                                        """)
-        else:
-            await maica_pool.query_modify("""
-CREATE TABLE IF NOT EXISTS mv_meta (
-  vista_id INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id INTEGER NOT NULL,
-  uuid TEXT NOT NULL,
-  timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-)
-                                        """)
-            await maica_pool.query_modify("""
-CREATE TRIGGER IF NOT EXISTS update_timestamp_mv_meta
-AFTER UPDATE ON mv_meta
-FOR EACH ROW
-BEGIN
-    UPDATE mv_meta
-    SET timestamp = CURRENT_TIMESTAMP
-    WHERE vista_id = OLD.vista_id;
-END;
-                                        """)
+        async with DatabaseUtils.engine_data.begin() as conn:
+            if conn.dialect.name == 'mysql':
+                await conn.execute(text('ALTER TABLE `account_status` CHANGE `status` `status` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL'))
+                await conn.execute(text('ALTER TABLE `account_status` CHANGE `preferences` `preferences` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL'))
+                await conn.execute(text('ALTER TABLE `ms_cache` CHANGE `hash` `hash` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL'))
+                await conn.execute(text('ALTER TABLE `ms_cache` CHANGE `content` `content` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL'))
+            await conn.run_sync(SqlMvMeta.__table__.create, checkfirst=True)
 
     except Exception as e:
         raise MaicaDbWarning(f'Couldn\'t alter lines LONGTEXT to TEXT and add table mv_meta: {str(e)}, maybe manually done already?') from e
-    finally:
-        await maica_pool.close()
         
 register_migration(upper_version, migrate)

--- a/maica/initializer/migrations/migration_3.py
+++ b/maica/initializer/migrations/migration_3.py
@@ -1,6 +1,4 @@
-import asyncio
-import os
-from typing import *
+from sqlalchemy import inspect, text
 from maica.maica_utils import *
 from .base import register_migration
 
@@ -8,30 +6,16 @@ upper_version = "1.2.003"
 
 async def migrate():
 
-    auth_pool = await ConnUtils.auth_pool(ro=False)
     try:
-        if auth_pool.db_type == 'mysql':
-            result = await auth_pool.query_get("select count(*) from information_schema.columns where table_name = 'users' and column_name = 'suspended_until'")
-            exist = result[0]
+        async with DatabaseUtils.engine_auth.begin() as conn:
+            columns = await conn.run_sync(lambda sync_conn: inspect(sync_conn).get_columns('users'))
+            exist = any(column['name'] == 'suspended_until' for column in columns)
             if not exist:
                 sync_messenger(info='Column does not exist, creating...', type=MsgType.DEBUG)
-                await auth_pool.query_modify('alter table `users` add column `suspended_until` datetime DEFAULT NULL')
-            else:
-                sync_messenger(info='Column already exists', type=MsgType.DEBUG)
-        else:
-            result = await auth_pool.query_get(
-                "SELECT name FROM pragma_table_info('users') WHERE name='suspended_until'"
-            )
-            if not result:
-                sync_messenger(info='Column does not exist, creating...', type=MsgType.DEBUG)
-                await auth_pool.query_modify(
-                    'ALTER TABLE users ADD COLUMN suspended_until TIMESTAMP'
-                )
+                await conn.execute(text('ALTER TABLE users ADD COLUMN suspended_until DATETIME DEFAULT NULL'))
             else:
                 sync_messenger(info='Column already exists', type=MsgType.DEBUG)
     except Exception as e:
         raise MaicaDbWarning(f'Couldn\'t add column \'suspended_until\' automatically: {str(e)}, consider doing a manual double-check') from e
-    finally:
-        await auth_pool.close()
 
 register_migration(upper_version, migrate)

--- a/maica/initializer/migrations/migration_4.py
+++ b/maica/initializer/migrations/migration_4.py
@@ -2,10 +2,18 @@ import asyncio
 import os
 from typing import *
 from pymilvus import DataType, CollectionSchema
+from sqlalchemy import inspect, text
 from maica.maica_utils import *
 from .base import register_migration
 
 upper_version = "1.3.000.rc1"
+
+async def _create_index_if_missing(conn, table_name: str, index_name: str, ddl: str):
+    indexes = await conn.run_sync(lambda sync_conn: inspect(sync_conn).get_indexes(table_name))
+    if any(index["name"] == index_name for index in indexes):
+        sync_messenger(info=f"Index {index_name} already exists on {table_name}, skipping...", type=MsgType.DEBUG)
+        return
+    await conn.execute(text(ddl))
 
 async def migrate():
     if G.A.MILVUS_ADDR:
@@ -65,31 +73,24 @@ async def migrate():
     else:
         sync_messenger(info="[maica-db] Milvus databse is not enabled, skipping...", type=MsgType.WARN)
 
-    maica_pool = await ConnUtils.maica_pool()
     try:
-        if maica_pool.db_type == 'mysql':
-            await maica_pool.query_modify("ALTER TABLE `account_status` CHANGE `status` `status` JSON NULL DEFAULT NULL; ")
-            await maica_pool.query_modify("ALTER TABLE `account_status` CHANGE `preferences` `preferences` JSON NULL DEFAULT NULL; ")
-            await maica_pool.query_modify("ALTER TABLE `crop_archived` CHANGE `archived` `archived` BOOLEAN NOT NULL DEFAULT '0'; ")
+        async with DatabaseUtils.engine_data.begin() as conn:
+            if conn.dialect.name == 'mysql':
+                await conn.execute(text("ALTER TABLE `account_status` CHANGE `status` `status` JSON NULL DEFAULT NULL"))
+                await conn.execute(text("ALTER TABLE `account_status` CHANGE `preferences` `preferences` JSON NULL DEFAULT NULL"))
+                await conn.execute(text("ALTER TABLE `crop_archived` CHANGE `archived` `archived` BOOLEAN NOT NULL DEFAULT '0'"))
 
-            await maica_pool.query_modify("ALTER TABLE ms_cache ADD UNIQUE INDEX uq_hash (hash(64));")
-            await maica_pool.query_modify("ALTER TABLE chat_session ADD UNIQUE INDEX uq_id_session (user_id, chat_session_num);")
-            await maica_pool.query_modify("ALTER TABLE persistents ADD UNIQUE INDEX uq_id_session (user_id, chat_session_num);")
-            await maica_pool.query_modify("ALTER TABLE triggers ADD UNIQUE INDEX uq_id_session (user_id, chat_session_num);")
-            
-        else:
-            # There's no actual json at all in sqlite
-            # Nor tinyint
+                await _create_index_if_missing(conn, "ms_cache", "uq_hash", "CREATE UNIQUE INDEX uq_hash ON ms_cache (hash(64))")
+            else:
+                # There's no actual json at all in sqlite, nor tinyint.
+                await _create_index_if_missing(conn, "ms_cache", "uq_hash", "CREATE UNIQUE INDEX uq_hash ON ms_cache (hash)")
 
-            await maica_pool.query_modify("ALTER TABLE ms_cache CREATE UNIQUE INDEX uq_hash ON ms_cache(hash);")
-            await maica_pool.query_modify("ALTER TABLE chat_session CREATE UNIQUE INDEX uq_id_session ON chat_session(user_id, chat_session_num);")
-            await maica_pool.query_modify("ALTER TABLE persistents CREATE UNIQUE INDEX uq_id_session ON persistents(user_id, chat_session_num);")
-            await maica_pool.query_modify("ALTER TABLE triggers CREATE UNIQUE INDEX uq_id_session ON triggers(user_id, chat_session_num);")
+            await _create_index_if_missing(conn, "chat_session", "uq_id_session", "CREATE UNIQUE INDEX uq_id_session ON chat_session (user_id, chat_session_num)")
+            await _create_index_if_missing(conn, "persistents", "uq_id_session", "CREATE UNIQUE INDEX uq_id_session ON persistents (user_id, chat_session_num)")
+            await _create_index_if_missing(conn, "triggers", "uq_id_session", "CREATE UNIQUE INDEX uq_id_session ON triggers (user_id, chat_session_num)")
 
     except Exception as e:
         raise MaicaDbWarning(f'Couldn\'t alter table: {str(e)}, maybe manually done already?') from e
-    finally:
-        await maica_pool.close()
 
 register_migration(upper_version, migrate)
 

--- a/maica/maica_utils/database_models.py
+++ b/maica/maica_utils/database_models.py
@@ -8,6 +8,10 @@ from typing import *
 from sqlalchemy import (
     UniqueConstraint,
     JSON,
+    Boolean,
+    DateTime,
+    String,
+    Text,
     inspect,
 )
 from sqlalchemy.sql import (
@@ -40,12 +44,12 @@ class SqlUser(SqlBaseAuth):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    username: Mapped[str] = mapped_column(unique=True)
-    nickname: Mapped[Optional[str]]
-    email: Mapped[str] = mapped_column(unique=True)
-    is_email_confirmed: Mapped[bool] = mapped_column(default=False)
-    password: Mapped[str]
-    suspended_until: Mapped[Optional[datetime.datetime]]
+    username: Mapped[str] = mapped_column(String(100), unique=True)
+    nickname: Mapped[Optional[str]] = mapped_column(String(255))
+    email: Mapped[str] = mapped_column(String(150), unique=True)
+    is_email_confirmed: Mapped[bool] = mapped_column(Boolean, default=False)
+    password: Mapped[str] = mapped_column(String(100))
+    suspended_until: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime)
 
 class SqlAccountStatus(SqlBaseData):
     __tablename__ = "account_status"
@@ -67,32 +71,34 @@ class SqlChatSession(SqlBaseData):
     )
 
     id: Mapped[int] = mapped_column("chat_session_id", primary_key=True)
-    user_id: Mapped[int] = mapped_column(unique=True)
+    user_id: Mapped[int]
     chat_session_num: Mapped[int]
-    content: Mapped[str]
+    content: Mapped[Optional[str]] = mapped_column(Text)
 
 class SqlCropArchived(SqlBaseData):
     __tablename__ = "crop_archived"
 
     id: Mapped[int] = mapped_column("archive_id", primary_key=True)
     chat_session_id: Mapped[int]
-    content: Mapped[str]
-    archived: Mapped[bool] = mapped_column(default=False)
+    content: Mapped[Optional[str]] = mapped_column(Text)
+    archived: Mapped[bool] = mapped_column(Boolean, default=False)
 
 class SqlCsessionArchived(SqlBaseData):
     __tablename__ = "csession_archived"
 
     id: Mapped[int] = mapped_column("archive_id", primary_key=True)
     chat_session_id: Mapped[int]
-    content: Mapped[str]
+    content: Mapped[Optional[str]] = mapped_column(Text)
 
 class SqlMsCache(SqlBaseData):
     __tablename__ = "ms_cache"
+    __table_args__ = (
+        UniqueConstraint("hash", name="uq_hash"),
+    )
 
     id: Mapped[int] = mapped_column("spire_id", primary_key=True)
-    user_id: Mapped[int]
-    hash: Mapped[str]
-    content: Mapped[str]
+    hash: Mapped[str] = mapped_column(String(255))
+    content: Mapped[Optional[str]] = mapped_column(Text)
     timestamp: Mapped[datetime.datetime] = mapped_column(
         server_default=func.now(),
         onupdate=func.now(),
@@ -103,7 +109,7 @@ class SqlMvMeta(SqlBaseData):
 
     id: Mapped[int] = mapped_column("vista_id", primary_key=True)
     user_id: Mapped[int]
-    uuid: Mapped[str]
+    uuid: Mapped[str] = mapped_column(Text)
     timestamp: Mapped[datetime.datetime] = mapped_column(
         server_default=func.now(),
         onupdate=func.now(),
@@ -118,7 +124,7 @@ class SqlPersistent(SqlBaseData):
     id: Mapped[int] = mapped_column("persistent_id", primary_key=True)
     user_id: Mapped[int]
     chat_session_num: Mapped[int]
-    content: Mapped[Optional[str]]
+    content: Mapped[Optional[str]] = mapped_column(Text)
     timestamp: Mapped[datetime.datetime] = mapped_column(
         server_default=func.now(),
         onupdate=func.now(),
@@ -133,7 +139,7 @@ class SqlTrigger(SqlBaseData):
     id: Mapped[int] = mapped_column("trigger_id", primary_key=True)
     user_id: Mapped[int]
     chat_session_num: Mapped[int]
-    content: Mapped[Optional[str]]
+    content: Mapped[Optional[str]] = mapped_column(Text)
     timestamp: Mapped[datetime.datetime] = mapped_column(
         server_default=func.now(),
         onupdate=func.now(),


### PR DESCRIPTION
### Motivation

- Replace legacy raw SQL / custom pool helpers with SQLAlchemy async engines and metadata so initial setup and migrations work with the new ORM layer.
- Normalize MySQL vs SQLite differences using SQLAlchemy execution/inspection instead of ad-hoc string queries.
- Align ORM model column types and constraints to match the intended schema used by the migrations and initializer.

### Description

- Rewrote `maica/initializer/init_db.py` to create MySQL databases via a server-level async engine and to create tables using `SqlBaseAuth.metadata.create_all` and `SqlBaseData.metadata.create_all` through SQLAlchemy async engines instead of `ConnUtils` raw queries.
- Converted migrations `migration_1.py`..`migration_4.py` to use `DatabaseUtils.engine_data` / `DatabaseUtils.engine_auth` with `text()` execution and SQLAlchemy inspection, removing `ConnUtils` `query_modify` calls and handling MySQL/SQLite syntax differences appropriately.
- In `migration_2.py` the `mv_meta` table is created via the ORM table metadata (`SqlMvMeta.__table__.create(checkfirst=True)`) and MySQL-only ALTERs are executed with `text()` when needed.
- In `migration_3.py` the presence of `suspended_until` is detected with SQLAlchemy `inspect` and the column is added with an `ALTER TABLE` executed via the SQLAlchemy connection when missing.
- In `migration_4.py` added helper `async def _create_index_if_missing` using SQLAlchemy `inspect(...).get_indexes` to avoid duplicate index creation, and applied table ALTERs / index creation through the async engine, preserving MySQL vs SQLite differences.
- Updated ORM definitions in `maica/maica_utils/database_models.py` to declare explicit types and constraints (`String`, `Text`, `Boolean`, `DateTime`), add `__table_args__` unique constraint for `ms_cache.hash`, and otherwise match the adjusted initializer/migration expectations.
- Removed direct use of legacy pool objects from the modified files and replaced them with SQLAlchemy engine/session based operations.

### Testing

- Ran a syntax/bytecode check with `python -m compileall maica/initializer/init_db.py maica/initializer/migrations/migration_1.py maica/initializer/migrations/migration_2.py maica/initializer/migrations/migration_3.py maica/initializer/migrations/migration_4.py maica/maica_utils/database_models.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50e89f7d5883268996f6bce347ee2c)